### PR TITLE
Time dependence 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Features
 Limitations
 -----------
  - Numeric integration is used to compute some differential rates, even in cases where exact expressions are known / could be derived.
- - The earth's motion w.r.t. to the sun is not taken into account: no annual modulation for you!
  - Not all functions are properly vectorized yet
 
 The package uses numericalunits (https://pypi.python.org/pypi/numericalunits); all function inputs

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+from wimprates import j2000
+
+
+def test_j2000():
+    assert j2000(2009, 1, 31.75) == 3318.25
+
+def test_j2000_datetime():
+    date = pd.datetime('2009-1-31 18:00:00')
+    assert j2000(date=date) == 3318.25

--- a/wimprates.py
+++ b/wimprates.py
@@ -37,7 +37,7 @@ v_esc = 544 * nu.km/nu.s
 # Maximum dark matter velocity observable on earth
 v_max = v_esc + v_earth
 
-# J2000.0 epoch conversion (converts datetime to fraction of year)
+# J2000.0 epoch conversion (converts datetime to days since epoch)
 # Zero of this convention is defined as 12h Terrestrial time on 1 January 2000
 # This is similar to UTC or GMT with negligible error (~1 minute).
 # See http://arxiv.org/abs/1312.1355 Appendix A for more details
@@ -89,6 +89,14 @@ def _v_earth_t(t):
     return v_orbit * (e_1 * np.cos(phi) + e_2 * np.sin(phi))
 
 
+def vmax_t(t=None):
+    """Calculate the maximum observable dark matter velocity on Earth."""
+    if t is None:
+        return v_esc + v_earth
+    else:
+        return v_esc + _v_earth_t(t)
+
+
 def observed_speed_dist(v, t=None):
     """Observed distribution of dark matter particle speeds on earth under
        the SHM
@@ -103,8 +111,8 @@ def observed_speed_dist(v, t=None):
     if t is None:
         v_earth_t = v_earth
     else:
-        v_LSR = np.array([0, v_earth, 0])
-        v_pec = np.array([11, 12, 7]) * nu.km/nu.s
+        v_LSR = np.array([0, v_earth, 0])  # Velocity in Local Standard of REST
+        v_pec = np.array([11, 12, 7]) * nu.km/nu.s  # Solar peculiar velocity
         vec = v_LSR + v_pec + _v_earth_t(t)
 
         v_earth_t = np.sum(vec**2)**0.5
@@ -126,13 +134,13 @@ def observed_speed_dist(v, t=None):
         len(v)
     except TypeError:
         # Scalar argument
-        if v > v_max:
+        if v > v_max_t(t):
             return 0
         else:
             return y
 
     # Array argument
-    y[v > v_max] = 0
+    y[v > v_max_t(t)] = 0
     return y
 
 

--- a/wimprates.py
+++ b/wimprates.py
@@ -34,9 +34,6 @@ v_orbit = 29.79 * nu.km / nu.s
 # Galactic escape velocity
 v_esc = 544 * nu.km/nu.s
 
-# Maximum dark matter velocity observable on earth
-v_max = v_esc + v_earth
-
 # J2000.0 epoch conversion (converts datetime to days since epoch)
 # Zero of this convention is defined as 12h Terrestrial time on 1 January 2000
 # This is similar to UTC or GMT with negligible error (~1 minute).
@@ -94,7 +91,7 @@ def _v_earth_t(t):
     return v_LSR + v_pec + v_earth_sun
 
 
-def v_max_t(t=None):
+def v_max(t=None):
     """Calculate the maximum observable dark matter velocity on Earth."""
     if t is None:
         return v_esc + v_earth
@@ -134,13 +131,13 @@ def observed_speed_dist(v, t=None):
         len(v)
     except TypeError:
         # Scalar argument
-        if v > v_max_t(t):
+        if v > v_max(t):
             return 0
         else:
             return y
 
     # Array argument
-    y[v > v_max_t(t)] = 0
+    y[v > v_max(t)] = 0
     return y
 
 
@@ -326,12 +323,12 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
 
     v_min = vmin_elastic(erec, mw)
 
-    if v_min >= v_max_t(t):
+    if v_min >= v_max(t):
         return 0
 
     return rho_dm / mw * (1 / mn) * integrate.quad(
         lambda v: sigma_erec(erec, v, mw, sigma_nucleon, interaction, m_med) * v * observed_speed_dist(v, t),
-        v_min, v_max_t(t), **kwargs
+        v_min, v_max(t), **kwargs
     )[0]
 
 
@@ -435,13 +432,13 @@ def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
             for e in (tqdm if progress_bar else lambda x: x)(w)
         ])
 
-    if vmin_w(w, mw) >= v_max_t(t):
+    if vmin_w(w, mw) >= v_max(t):
         return 0
 
     return rho_dm / mw * (1 / mn) * integrate.quad(
         lambda v: sigma_w(w, v, mw, sigma_nucleon, interaction, m_med) *
                     v * observed_speed_dist(v, t),
-                    vmin_w(w, mw), v_max_t(t), **kwargs
+                    vmin_w(w, mw), v_max(t), **kwargs
     )[0]
 
 
@@ -497,7 +494,7 @@ def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
         ])
 
     # Maximum recoil energy for a nucleus
-    e_max = 2 * mu_nucleus(mw)**2 * v_max_t(t)**2 / mn
+    e_max = 2 * mu_nucleus(mw)**2 * v_max(t)**2 / mn
 
     result = 0
     for state, binding_e in binding_es_for_migdal.items():
@@ -533,7 +530,7 @@ def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
             diff_rate,
             0, e_max,
             lambda erec: vmin_migdal(w, erec, mw),
-            lambda _: v_max_t(t),
+            lambda _: v_max(t),
             args=(t),
             **kwargs)[0]
 


### PR DESCRIPTION
This PR implements the effect of the Earth orbital motion on the observed dark matter speed distribution. It adds a function to compute the velocity of the Earth with respect to the galactic rest frame in galactic coordinates at a given time (details and paper references are in the various docstrings and comments).
All times use the J2000.0 epoch convention, a utility function is provided to convert regular pandas datetime objects to the J2000.0 times.
All energy spectra functions using the observed speed distribution have an additional optional time argument. Default behaviour is unaltered and uses the conservative mean earth velocity (resulting in the 'winter' speed distribution).
Unit tests for the J2000.0 utility are provided (in testing is added in the future).