### PR TITLE
Use halo model class

### DIFF
--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -1,11 +1,11 @@
 import pandas as pd
-from wimprates import j2000, standard_halo_model
+from wimprates import j2000, StandardHaloModel
 import numericalunits as nu
 import numpy as np
 
 
 def test_shm_values():
-    halo_model = standard_halo_model()
+    halo_model = StandardHaloModel()
     assert np.abs(halo_model.v_0 /(nu.km/nu.s) - 220.)<1e-6
     assert np.abs(halo_model.v_esc /(nu.km/nu.s) - 544.)<1e-6
 

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -1,6 +1,13 @@
 import pandas as pd
-from wimprates import j2000
+from wimprates import j2000, standard_halo_model
+import numericalunits as nu
+import numpy as np
 
+
+def test_shm_values():
+    halo_model = standard_halo_model()
+    assert np.abs(halo_model.v_0 /(nu.km/nu.s) - 220.)<1e-6
+    assert np.abs(halo_model.v_esc /(nu.km/nu.s) - 544.)<1e-6
 
 def test_j2000():
     assert j2000(2009, 1, 31.75) == 3318.25

--- a/tests/test_wimprates.py
+++ b/tests/test_wimprates.py
@@ -23,7 +23,7 @@ def test_elastic():
     isclose(wr.rate_wimp_std(1, **opts), ref)
 
     # Test numericalunits.reset_units() does not affect results
-    nu.reset_units("SI")
+    nu.reset_units(123)
     isclose(wr.rate_wimp_std(1, **opts), ref)
 
     # Test vectorized call
@@ -63,5 +63,5 @@ def test_halo_scaling():
     #check that passing rho multiplies the rate correctly:
     ref = 33.19098343826968
 
-    isclose(wr.rate_wimp_std(1,halo_model = wr.standard_halo_model(rho_dm_value = wr.rho_dm()) , **opts), ref)
+    isclose(wr.rate_wimp_std(1,halo_model = wr.StandardHaloModel(rho_dm = 0.3 * nu.GeV/nu.c0**2 / nu.cm**3) , **opts), ref)
 

--- a/tests/test_wimprates.py
+++ b/tests/test_wimprates.py
@@ -23,7 +23,7 @@ def test_elastic():
     isclose(wr.rate_wimp_std(1, **opts), ref)
 
     # Test numericalunits.reset_units() does not affect results
-    nu.reset_units()
+    nu.reset_units("SI")
     isclose(wr.rate_wimp_std(1, **opts), ref)
 
     # Test vectorized call
@@ -58,3 +58,10 @@ def test_dme():
                     mw=nu.GeV/nu.c0**2, sigma_dme=4e-44 * nu.cm**2)
             * nu.kg * nu.keV * nu.day,
     2.232912243660405e-06)
+
+def test_halo_scaling():
+    #check that passing rho multiplies the rate correctly:
+    ref = 33.19098343826968
+
+    isclose(wr.rate_wimp_std(1,halo_model = wr.standard_halo_model(rho_dm_value = wr.rho_dm()) , **opts), ref)
+

--- a/wimprates/bremsstrahlung.py
+++ b/wimprates/bremsstrahlung.py
@@ -102,8 +102,8 @@ def sigma_w(w, v, mw, sigma_nucleon,
 @export
 @wr.vectorize_first
 def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
-                        m_med=float('inf'), t=None, 
-                        halo_model = None,**kwargs):
+                        m_med=float('inf'), t=None,
+                        halo_model=None, **kwargs):
     """Differential rate per unit detector mass and recoil energy of
     Bremsstrahlung elastic WIMP-nucleus scattering.
 
@@ -113,7 +113,8 @@ def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
     :param m_med: Mediator mass. If not given, assumed very heavy.
     :param t: A J2000.0 timestamp. If not given,
     a conservative velocity distribution is used.
-    :param halo_model: class (default to standard halo model) containing velocity distribution
+    :param halo_model: class (default to standard halo model)
+    containing velocity distribution
     :param interaction: string describing DM-nucleus interaction.
     See sigma_erec for options
     :param progress_bar: if True, show a progress bar during evaluation
@@ -122,7 +123,7 @@ def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
     Further kwargs are passed to scipy.integrate.quad numeric integrator
     (e.g. error tolerance).
     """
-    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
+    halo_model = wr.StandardHaloModel() if halo_model is None else halo_model
     vmin = vmin_w(w, mw)
 
     if vmin >= wr.v_max(t, halo_model.v_esc):

--- a/wimprates/bremsstrahlung.py
+++ b/wimprates/bremsstrahlung.py
@@ -103,7 +103,7 @@ def sigma_w(w, v, mw, sigma_nucleon,
 @wr.vectorize_first
 def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
                         m_med=float('inf'), t=None, 
-                        halo_model = wr.standard_halo_model(),**kwargs):
+                        halo_model = None,**kwargs):
     """Differential rate per unit detector mass and recoil energy of
     Bremsstrahlung elastic WIMP-nucleus scattering.
 
@@ -122,6 +122,7 @@ def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
     Further kwargs are passed to scipy.integrate.quad numeric integrator
     (e.g. error tolerance).
     """
+    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
     vmin = vmin_w(w, mw)
 
     if vmin >= wr.v_max(t, halo_model.v_esc):

--- a/wimprates/bremsstrahlung.py
+++ b/wimprates/bremsstrahlung.py
@@ -102,7 +102,8 @@ def sigma_w(w, v, mw, sigma_nucleon,
 @export
 @wr.vectorize_first
 def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
-                        m_med=float('inf'), t=None, **kwargs):
+                        m_med=float('inf'), t=None, 
+                        halo_model = wr.standard_halo_model(),**kwargs):
     """Differential rate per unit detector mass and recoil energy of
     Bremsstrahlung elastic WIMP-nucleus scattering.
 
@@ -112,6 +113,7 @@ def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
     :param m_med: Mediator mass. If not given, assumed very heavy.
     :param t: A J2000.0 timestamp. If not given,
     a conservative velocity distribution is used.
+    :param halo_model: class (default to standard halo model) containing velocity distribution
     :param interaction: string describing DM-nucleus interaction.
     See sigma_erec for options
     :param progress_bar: if True, show a progress bar during evaluation
@@ -122,17 +124,17 @@ def rate_bremsstrahlung(w, mw, sigma_nucleon, interaction='SI',
     """
     vmin = vmin_w(w, mw)
 
-    if vmin >= wr.v_max(t):
+    if vmin >= wr.v_max(t, halo_model.v_esc):
         return 0
 
     def integrand(v):
         return (sigma_w(w, v, mw, sigma_nucleon, interaction, m_med) *
-                v * wr.observed_speed_dist(v, t))
+                v * halo_model.velocity_dist(v, t))
 
-    return wr.rho_dm() / mw * (1 / wr.mn()) * quad(
+    return halo_model.rho_dm / mw * (1 / wr.mn()) * quad(
         integrand,
         vmin,
-        wr.v_max(t),
+        wr.v_max(t, halo_model.v_esc),
         **kwargs)[0]
 
 

--- a/wimprates/elastic_nr.py
+++ b/wimprates/elastic_nr.py
@@ -206,8 +206,7 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
         return 0
 
     def integrand(v):
-        return (sigma_erec(erec, v, mw, sigma_nucleon, interaction, m_med)
-                * v * halo_model.velocity_dist(v, t))
+        return (sigma_erec(erec, v, mw, sigma_nucleon, interaction, m_med) * v * halo_model.velocity_dist(v, t))
 
     return halo_model.rho_dm / mw * (1 / mn()) * quad(
         integrand,

--- a/wimprates/elastic_nr.py
+++ b/wimprates/elastic_nr.py
@@ -177,8 +177,9 @@ def vmin_elastic(erec, mw):
 
 @export
 @wr.vectorize_first
-def rate_elastic(erec, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
-                 t=None, **kwargs):
+def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
+        m_med=float('inf'), t=None, 
+        halo_model = wr.standard_halo_model(), **kwargs):
     """Differential rate per unit detector mass and recoil energy of
     elastic WIMP scattering
 
@@ -190,6 +191,7 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
     :param m_med: Mediator mass. If not given, assumed very heavy.
     :param t: A J2000.0 timestamp.
     If not given, conservative velocity distribution is used.
+    :param halo_model: class (default to standard halo model) containing velocity distribution
     :param progress_bar: if True, show a progress bar during evaluation
     (if erec is an array)
 
@@ -200,14 +202,14 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
     """
     v_min = vmin_elastic(erec, mw)
 
-    if v_min >= wr.v_max(t):
+    if v_min >= wr.v_max(t, halo_model.v_esc):
         return 0
 
     def integrand(v):
         return (sigma_erec(erec, v, mw, sigma_nucleon, interaction, m_med)
-                * v * wr.observed_speed_dist(v, t))
+                * v * halo_model.velocity_dist(v, t))
 
-    return wr.rho_dm() / mw * (1 / mn()) * quad(
+    return halo_model.rho_dm / mw * (1 / mn()) * quad(
         integrand,
-        v_min, wr.v_max(t),
+        v_min, wr.v_max(t, halo_model.v_esc),
         **kwargs)[0]

--- a/wimprates/elastic_nr.py
+++ b/wimprates/elastic_nr.py
@@ -179,7 +179,7 @@ def vmin_elastic(erec, mw):
 @wr.vectorize_first
 def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
         m_med=float('inf'), t=None, 
-        halo_model = wr.standard_halo_model(), **kwargs):
+        halo_model = None, **kwargs):
     """Differential rate per unit detector mass and recoil energy of
     elastic WIMP scattering
 
@@ -200,6 +200,7 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
 
     Analytic expressions are known for this rate, but they are not used here.
     """
+    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
     v_min = vmin_elastic(erec, mw)
 
     if v_min >= wr.v_max(t, halo_model.v_esc):

--- a/wimprates/elastic_nr.py
+++ b/wimprates/elastic_nr.py
@@ -178,8 +178,8 @@ def vmin_elastic(erec, mw):
 @export
 @wr.vectorize_first
 def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
-        m_med=float('inf'), t=None, 
-        halo_model = None, **kwargs):
+                 m_med=float('inf'), t=None,
+                 halo_model=None, **kwargs):
     """Differential rate per unit detector mass and recoil energy of
     elastic WIMP scattering
 
@@ -191,7 +191,8 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
     :param m_med: Mediator mass. If not given, assumed very heavy.
     :param t: A J2000.0 timestamp.
     If not given, conservative velocity distribution is used.
-    :param halo_model: class (default to standard halo model) containing velocity distribution
+    :param halo_model: class (default to standard halo model)
+    containing velocity distribution
     :param progress_bar: if True, show a progress bar during evaluation
     (if erec is an array)
 
@@ -200,14 +201,16 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
 
     Analytic expressions are known for this rate, but they are not used here.
     """
-    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
+    halo_model = wr.StandardHaloModel() if halo_model is None else halo_model
     v_min = vmin_elastic(erec, mw)
 
     if v_min >= wr.v_max(t, halo_model.v_esc):
         return 0
 
     def integrand(v):
-        return (sigma_erec(erec, v, mw, sigma_nucleon, interaction, m_med) * v * halo_model.velocity_dist(v, t))
+        return (sigma_erec(erec, v, mw, sigma_nucleon,
+                           interaction, m_med) * v
+                * halo_model.velocity_dist(v, t))
 
     return halo_model.rho_dm / mw * (1 / mn()) * quad(
         integrand,

--- a/wimprates/electron.py
+++ b/wimprates/electron.py
@@ -146,7 +146,7 @@ def rate_dme(erec, n, l, mw, sigma_dme,
         # Note dblquad expects the function to be f(y, x), not f(x, y)...
         def diff_xsec(v, q):
             result = q * dme_ionization_ff(shell, erec, q)
-            result *= 1 / v * halo_model.valocity_dist(v, t)
+            result *= 1 / v * halo_model.velocity_dist(v, t)
             return result
 
         r = dblquad(

--- a/wimprates/electron.py
+++ b/wimprates/electron.py
@@ -74,13 +74,12 @@ def binding_es_for_dme(n, l):
 
 
 @export
-def v_min_dme(eb, erec, q, mw, halo_model = wr.standard_halo_model()):
+def v_min_dme(eb, erec, q, mw):
     """Minimal DM velocity for DM-electron scattering
     :param eb: binding energy of shell
     :param erec: electronic recoil energy energy
     :param q: momentum transfer
     :param mw: DM mass
-    :param halo_model: class (default to standard halo model) containing velocity distribution
     """
     return (erec + eb) / q + q / (2 * mw)
 
@@ -106,7 +105,7 @@ inverse_mean_speed_kms = interp1d(
 @export
 @wr.vectorize_first
 def rate_dme(erec, n, l, mw, sigma_dme,
-             t=None, halo_model = wr.standard_halo_model(), **kwargs):
+             t=None, halo_model = None, **kwargs):
     """Return differential rate of dark matter electron scattering vs energy
     (i.e. dr/dE, not dr/dlogE)
     :param erec: Electronic recoil energy
@@ -119,6 +118,7 @@ def rate_dme(erec, n, l, mw, sigma_dme,
     If not given, a conservative velocity distribution is used.
     :param halo_model: class (default to standard halo model) containing velocity distribution
     """
+    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
     shell = shell_str(n, l)
     eb = binding_es_for_dme(n, l)
 
@@ -131,7 +131,7 @@ def rate_dme(erec, n, l, mw, sigma_dme,
         # Use precomputed inverse mean speed,
         # so we only have to do a single integral
         def diff_xsec(q):
-            vmin = v_min_dme(eb, erec, q, mw, halo_model=halo_model)
+            vmin = v_min_dme(eb, erec, q, mw)
             result = q * dme_ionization_ff(shell, erec, q)
             # Note the interpolator is in kms, not unit-carrying numbers
             # see above

--- a/wimprates/electron.py
+++ b/wimprates/electron.py
@@ -86,11 +86,11 @@ def v_min_dme(eb, erec, q, mw, halo_model = wr.standard_halo_model()):
 
 
 # Precompute velocity integrals for t=None
-_v_mins = np.linspace(0, 1, 1000) * wr.v_max(None, halo_model.v_esc)
+_v_mins = np.linspace(0, 1, 1000) * wr.v_max(None, wr.v_esc())
 _ims = np.array([
-    quad(lambda v: 1 / v * halo_model.velocity_dist(v),
+    quad(lambda v: 1 / v * wr.observed_speed_dist(v),
          _v_min,
-         wr.v_max(None, halo_model.v_esc))[0]
+         wr.v_max(None, wr.v_esc() ))[0]
     for _v_min in _v_mins])
 
 # Store interpolator in km/s rather than unit-dependent numbers

--- a/wimprates/halo.py
+++ b/wimprates/halo.py
@@ -110,8 +110,9 @@ def v_earth(t=None):
 
 
 @export
-def v_max(t=None,v_esc_value = v_esc()):
+def v_max(t=None,v_esc_value = None):
     """Return maximum observable dark matter velocity on Earth."""
+    v_esc_value = v_esc() if v_esc_value is None else v_esc_value #default args do not change value when you do a reset_unit so this is necessary to avoid errors
     if t is None:
         return v_esc_value + v_earth(t)
     else:
@@ -119,7 +120,7 @@ def v_max(t=None,v_esc_value = v_esc()):
 
 
 @export
-def observed_speed_dist(v, t=None, v_0_value=v_0(), v_esc_value=v_esc()):
+def observed_speed_dist(v, t=None, v_0_value=None, v_esc_value=None):
     """Observed distribution of dark matter particle speeds on earth
     under the standard halo model.
 
@@ -132,6 +133,8 @@ def observed_speed_dist(v, t=None, v_0_value=v_0(), v_esc_value=v_esc()):
 
     Further inputs: scale velocity v_0_value and escape velocity v_esc_value
     """
+    v_0_value = v_0() if v_0_value is None else v_0_value
+    v_esc_value = v_esc() if v_esc_value is None else v_esc_value
     v_earth_t = v_earth(t)
 
     # Normalization constant, see Lewin&Smith appendix 1a
@@ -175,10 +178,10 @@ class standard_halo_model:
         The standard halo model also allows variation of v_0
         :param v_0 
     """
-    def __init__(self, v_0_value = v_0(), v_esc_value=v_esc(),rho_dm_value=rho_dm()):
-        self.v_0 = v_0_value
-        self.v_esc = v_esc_value
-        self.rho_dm = rho_dm_value
+    def __init__(self, v_0_value =None, v_esc_value=None,rho_dm_value=None):
+        self.v_0 = v_0() if v_0_value is None else v_0_value
+        self.v_esc = v_esc() if v_esc_value is None else v_esc_value
+        self.rho_dm = rho_dm() if rho_dm_value is None else rho_dm_value
     def velocity_dist(self,v,t):
         #in units of per velocity, 
         #v is in units of velocity 

--- a/wimprates/halo.py
+++ b/wimprates/halo.py
@@ -136,17 +136,19 @@ def observed_speed_dist(v, t=None, v_0_value=v_0(), v_esc_value=v_esc()):
 
     # Normalization constant, see Lewin&Smith appendix 1a
     _w = v_esc_value/v_0_value
-    k = erf(_w) - 2/np.pi**0.5 * _w * np.exp(-_w**2)
+    k = erf(_w) - 2/np.pi**0.5 * _w * np.exp(-_w**2) #unitless
 
     # Maximum cos(angle) for this velocity, otherwise v0
     xmax = np.minimum(1,
                       (v_esc_value**2 - v_earth_t**2 - v**2)
                       / (2 * v_earth_t * v))
+    #unitless
 
     y = (k * v / (np.pi**0.5 * v_0_value * v_earth_t)
          * (np.exp(-((v-v_earth_t)/v_0_value)**2)
             - np.exp(-1/v_0_value**2 * (v**2 + v_earth_t**2
                                     + 2 * v * v_earth_t * xmax))))
+            #units / (velocity)
 
     # Zero if v > v_max
     try:
@@ -173,11 +175,11 @@ class standard_halo_model:
         The standard halo model also allows variation of v_0
         :param v_0 
     """
-    def __init__(self, v_0_value = v_0(), v_esc_value=v_esc(),rho_dm_value=rho_dm())
+    def __init__(self, v_0_value = v_0(), v_esc_value=v_esc(),rho_dm_value=rho_dm()):
         self.v_0 = v_0_value
         self.v_esc = v_esc_value
         self.rho_dm = rho_dm_value
     def velocity_dist(self,v,t):
         #in units of per velocity, 
         #v is in units of velocity 
-        return observed_speed_dist(v, t=None, self.v_0, self.v_esc)
+        return observed_speed_dist(v, t, self.v_0, self.v_esc)

--- a/wimprates/halo.py
+++ b/wimprates/halo.py
@@ -10,26 +10,6 @@ import wimprates as wr
 export, __all__ = wr.exporter()
 
 
-@export
-def rho_dm():
-    """Local dark matter density"""
-    return 0.3 * nu.GeV/nu.c0**2 / nu.cm**3
-
-
-@export
-def v_0():
-    """Most common velocity of WIMPs in the halo,
-    relative to galactic center (asymptotic)
-    """
-    return 220 * nu.km/nu.s
-
-
-@export
-def v_esc():
-    """Galactic escape velocity"""
-    return 544 * nu.km/nu.s
-
-
 # J2000.0 epoch conversion (converts datetime to days since epoch)
 # Zero of this convention is defined as 12h Terrestrial time on 1 January 2000
 # This is similar to UTC or GMT with negligible error (~1 minute).
@@ -110,17 +90,19 @@ def v_earth(t=None):
 
 
 @export
-def v_max(t=None,v_esc_value = None):
+def v_max(t=None, v_esc=None):
     """Return maximum observable dark matter velocity on Earth."""
-    v_esc_value = v_esc() if v_esc_value is None else v_esc_value #default args do not change value when you do a reset_unit so this is necessary to avoid errors
+    v_esc = 544 * nu.km/nu.s if v_esc is None else v_esc  # default
+    # args do not change value when you do a
+    # reset_unit so this is necessary to avoid errors
     if t is None:
-        return v_esc_value + v_earth(t)
+        return v_esc + v_earth(t)
     else:
-        return v_esc_value + np.sum(earth_velocity(t) ** 2) ** 0.5
+        return v_esc + np.sum(earth_velocity(t) ** 2) ** 0.5
 
 
 @export
-def observed_speed_dist(v, t=None, v_0_value=None, v_esc_value=None):
+def observed_speed_dist(v, t=None, v_0=None, v_esc=None):
     """Observed distribution of dark matter particle speeds on earth
     under the standard halo model.
 
@@ -131,58 +113,63 @@ def observed_speed_dist(v, t=None, v_0_value=None, v_esc_value=None):
     Optionally supply J2000.0 time t to take into account Earth's orbital
     velocity.
 
-    Further inputs: scale velocity v_0_value and escape velocity v_esc_value
+    Further inputs: scale velocity v_0 and escape velocity v_esc_value
     """
-    v_0_value = v_0() if v_0_value is None else v_0_value
-    v_esc_value = v_esc() if v_esc_value is None else v_esc_value
+    v_0 = 220 * nu.km/nu.s if v_0 is None else v_0
+    v_esc = 544 * nu.km/nu.s if v_esc is None else v_esc
     v_earth_t = v_earth(t)
 
     # Normalization constant, see Lewin&Smith appendix 1a
-    _w = v_esc_value/v_0_value
-    k = erf(_w) - 2/np.pi**0.5 * _w * np.exp(-_w**2) #unitless
+    _w = v_esc/v_0
+    k = erf(_w) - 2/np.pi**0.5 * _w * np.exp(-_w**2)  # unitless
 
     # Maximum cos(angle) for this velocity, otherwise v0
     xmax = np.minimum(1,
-                      (v_esc_value**2 - v_earth_t**2 - v**2)
+                      (v_esc**2 - v_earth_t**2 - v**2)
                       / (2 * v_earth_t * v))
-    #unitless
+    # unitless
 
-    y = (k * v / (np.pi**0.5 * v_0_value * v_earth_t)
-         * (np.exp(-((v-v_earth_t)/v_0_value)**2)
-            - np.exp(-1/v_0_value**2 * (v**2 + v_earth_t**2
-                                    + 2 * v * v_earth_t * xmax))))
-            #units / (velocity)
+    y = (k * v / (np.pi**0.5 * v_0 * v_earth_t)
+         * (np.exp(-((v-v_earth_t)/v_0)**2)
+         - np.exp(-1/v_0**2 * (v**2 + v_earth_t**2
+                  + 2 * v * v_earth_t * xmax))))
+    # units / (velocity)
 
     # Zero if v > v_max
     try:
         len(v)
     except TypeError:
         # Scalar argument
-        if v > v_max(t, v_esc_value):
+        if v > v_max(t, v_esc):
             return 0
         else:
             return y
     else:
         # Array argument
-        y[v > v_max(t, v_esc_value)] = 0
+        y[v > v_max(t, v_esc)] = 0
         return y
 
-@export 
-class standard_halo_model:
+
+@export
+class StandardHaloModel:
     """
         class used to pass a halo model to the rate computation
-        must contain: 
+        must contain:
         :param v_esc -- escape velocity
-        :function velocity_dist -- function taking v,t giving normalised valocity distribution in earth rest-frame. 
+        :function velocity_dist -- function taking v,t
+        giving normalised valocity distribution in earth rest-frame.
         :param rho_dm -- density in mass/volume of dark matter at the Earth
         The standard halo model also allows variation of v_0
-        :param v_0 
+        :param v_0
     """
-    def __init__(self, v_0_value =None, v_esc_value=None,rho_dm_value=None):
-        self.v_0 = v_0() if v_0_value is None else v_0_value
-        self.v_esc = v_esc() if v_esc_value is None else v_esc_value
-        self.rho_dm = rho_dm() if rho_dm_value is None else rho_dm_value
-    def velocity_dist(self,v,t):
-        #in units of per velocity, 
-        #v is in units of velocity 
+
+    def __init__(self, v_0=None, v_esc=None, rho_dm=None):
+        self.v_0 = 220 * nu.km/nu.s if v_0 is None else v_0
+        self.v_esc = 544 * nu.km/nu.s if v_esc is None else v_esc
+        self.rho_dm = 0.3 * nu.GeV/nu.c0**2 / nu.cm**3 if rho_dm is None else rho_dm
+
+    def velocity_dist(self, v, t):
+        # in units of per velocity,
+        # v is in units of velocity
         return observed_speed_dist(v, t, self.v_0, self.v_esc)
+

--- a/wimprates/migdal.py
+++ b/wimprates/migdal.py
@@ -41,7 +41,7 @@ def vmin_migdal(w, erec, mw):
 @wr.vectorize_first
 def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
                 include_approx_nr=False,
-                t=None, halo_model = None, **kwargs):
+                t=None, halo_model=None, **kwargs):
     """Differential rate per unit detector mass and deposited ER energy of
     Migdal effect WIMP-nucleus scattering
 
@@ -58,14 +58,15 @@ def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
         presented the Migdal spectra.
     :param t: A J2000.0 timestamp.
     If not given, conservative velocity distribution is used.
-    :param halo_model: class (default to standard halo model) containing velocity distribution
+    :param halo_model: class (default to standard halo model)
+    containing velocity distribution
     :param progress_bar: if True, show a progress bar during evaluation
     (if w is an array)
 
     Further kwargs are passed to scipy.integrate.quad numeric integrator
     (e.g. error tolerance).
     """
-    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
+    halo_model = wr.StandardHaloModel() if halo_model is None else halo_model
     include_approx_nr = 1 if include_approx_nr else 0
 
     result = 0

--- a/wimprates/migdal.py
+++ b/wimprates/migdal.py
@@ -41,7 +41,7 @@ def vmin_migdal(w, erec, mw):
 @wr.vectorize_first
 def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
                 include_approx_nr=False,
-                t=None, **kwargs):
+                t=None, halo_model = wr.standard_halo_model(), **kwargs):
     """Differential rate per unit detector mass and deposited ER energy of
     Migdal effect WIMP-nucleus scattering
 
@@ -58,6 +58,7 @@ def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
         presented the Migdal spectra.
     :param t: A J2000.0 timestamp.
     If not given, conservative velocity distribution is used.
+    :param halo_model: class (default to standard halo model) containing velocity distribution
     :param progress_bar: if True, show a progress bar during evaluation
     (if w is an array)
 
@@ -93,7 +94,7 @@ def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
                 # common constants follow at end
                 wr.sigma_erec(erec, v, mw, sigma_nucleon, interaction,
                               m_med=m_med)
-                * v * wr.observed_speed_dist(v, t)
+                * v * halo_model.velocity_dist(v, t)
 
                 # Migdal effect |Z|^2
                 # TODO: ?? what is explicit (eV/c)**2 doing here?
@@ -105,12 +106,12 @@ def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
         r = dblquad(
             diff_rate,
             0,
-            wr.e_max(mw, wr.v_max(t)),
+            wr.e_max(mw, wr.v_max(t, halo_model.v_esc)),
             lambda erec: vmin_migdal(w - include_approx_nr * erec * 0.15,
                                      erec, mw),
-            lambda _: wr.v_max(t),
+            lambda _: wr.v_max(t, halo_model.v_esc),
             **kwargs)[0]
 
         result += r
 
-    return wr.rho_dm() / mw * (1 / wr.mn()) * result
+    return halo_model.rho_dm / mw * (1 / wr.mn()) * result

--- a/wimprates/migdal.py
+++ b/wimprates/migdal.py
@@ -41,7 +41,7 @@ def vmin_migdal(w, erec, mw):
 @wr.vectorize_first
 def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
                 include_approx_nr=False,
-                t=None, halo_model = wr.standard_halo_model(), **kwargs):
+                t=None, halo_model = None, **kwargs):
     """Differential rate per unit detector mass and deposited ER energy of
     Migdal effect WIMP-nucleus scattering
 
@@ -65,6 +65,7 @@ def rate_migdal(w, mw, sigma_nucleon, interaction='SI', m_med=float('inf'),
     Further kwargs are passed to scipy.integrate.quad numeric integrator
     (e.g. error tolerance).
     """
+    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
     include_approx_nr = 1 if include_approx_nr else 0
 
     result = 0

--- a/wimprates/summary.py
+++ b/wimprates/summary.py
@@ -10,7 +10,7 @@ export, __all__ = wr.exporter()
 @export
 def rate_wimp(es, mw, sigma_nucleon, interaction='SI',
               detection_mechanism='elastic_nr', m_med=float('inf'),
-              t=None, halo_model = wr.standard_halo_model() ,
+              t=None, halo_model = None ,
               **kwargs):
     """Differential rate per unit time, unit detector mass
     and unit recoil energy of WIMP-nucleus scattering.
@@ -43,6 +43,7 @@ def rate_wimp(es, mw, sigma_nucleon, interaction='SI',
     Further kwargs are passed to scipy.integrate.quad numeric integrator
     (e.g. error tolerance).
     """
+    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
     dmechs = dict(elastic_nr=wr.rate_elastic,
                   bremsstrahlung=wr.rate_bremsstrahlung,
                   migdal=wr.rate_migdal)
@@ -56,7 +57,7 @@ def rate_wimp(es, mw, sigma_nucleon, interaction='SI',
 
 @export
 def rate_wimp_std(es, mw, sigma_nucleon, m_med=float('inf'),
-        t=None, halo_model = wr.standard_halo_model() , **kwargs):
+        t=None, halo_model = None , **kwargs):
     """Differential rate per (ton year keV) of WIMP-nucleus scattering.
     :param es: Recoil energies in keV
     :param mw: WIMP mass in GeV/c^2
@@ -69,6 +70,7 @@ def rate_wimp_std(es, mw, sigma_nucleon, m_med=float('inf'),
 
     Further arguments are as for rate_wimp; see docstring of rate_wimp.
     """
+    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
     return (rate_wimp(es=es * nu.keV,
                       mw=mw * nu.GeV/nu.c0**2,
                       sigma_nucleon=sigma_nucleon * nu.cm**2,

--- a/wimprates/summary.py
+++ b/wimprates/summary.py
@@ -10,7 +10,7 @@ export, __all__ = wr.exporter()
 @export
 def rate_wimp(es, mw, sigma_nucleon, interaction='SI',
               detection_mechanism='elastic_nr', m_med=float('inf'),
-              t=None, halo_model = None ,
+              t=None, halo_model=None,
               **kwargs):
     """Differential rate per unit time, unit detector mass
     and unit recoil energy of WIMP-nucleus scattering.
@@ -43,7 +43,7 @@ def rate_wimp(es, mw, sigma_nucleon, interaction='SI',
     Further kwargs are passed to scipy.integrate.quad numeric integrator
     (e.g. error tolerance).
     """
-    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
+    halo_model = wr.StandardHaloModel() if halo_model is None else halo_model
     dmechs = dict(elastic_nr=wr.rate_elastic,
                   bremsstrahlung=wr.rate_bremsstrahlung,
                   migdal=wr.rate_migdal)
@@ -57,7 +57,7 @@ def rate_wimp(es, mw, sigma_nucleon, interaction='SI',
 
 @export
 def rate_wimp_std(es, mw, sigma_nucleon, m_med=float('inf'),
-        t=None, halo_model = None , **kwargs):
+                  t=None, halo_model=None, **kwargs):
     """Differential rate per (ton year keV) of WIMP-nucleus scattering.
     :param es: Recoil energies in keV
     :param mw: WIMP mass in GeV/c^2
@@ -65,15 +65,16 @@ def rate_wimp_std(es, mw, sigma_nucleon, m_med=float('inf'),
     :param m_med: Medator mass in GeV/c^2. If not given, assumed very heavy.
     :param t: A J2000.0 timestamp. If not given,
     conservative velocity distribution is used.
-    :function halo_model : class (similar to the standard halo model) giving velocity distribution and dark matter density
+    :function halo_model : class (similar to the standard
+    halo model) giving velocity distribution and dark matter density
     :returns: numpy array of same length as es
 
     Further arguments are as for rate_wimp; see docstring of rate_wimp.
     """
-    halo_model = wr.standard_halo_model() if halo_model is None else halo_model
+    halo_model = wr.StandardHaloModel() if halo_model is None else halo_model
     return (rate_wimp(es=es * nu.keV,
                       mw=mw * nu.GeV/nu.c0**2,
                       sigma_nucleon=sigma_nucleon * nu.cm**2,
-                      m_med=m_med * nu.GeV/nu.c0**2, 
+                      m_med=m_med * nu.GeV/nu.c0**2,
                       t=t, halo_model=halo_model, **kwargs)
             * (nu.keV * (1000 * nu.kg) * nu.year))

--- a/wimprates/summary.py
+++ b/wimprates/summary.py
@@ -9,7 +9,8 @@ export, __all__ = wr.exporter()
 
 @export
 def rate_wimp(es, mw, sigma_nucleon, interaction='SI',
-              detection_mechanism='elastic_nr', m_med=float('inf'), t=None,
+              detection_mechanism='elastic_nr', m_med=float('inf'),
+              t=None, halo_model = wr.standard_halo_model() ,
               **kwargs):
     """Differential rate per unit time, unit detector mass
     and unit recoil energy of WIMP-nucleus scattering.
@@ -50,11 +51,12 @@ def rate_wimp(es, mw, sigma_nucleon, interaction='SI',
             "Unsupported detection mechanism '%s'" % detection_mechanism)
     return dmechs[detection_mechanism](
         es, mw=mw, sigma_nucleon=sigma_nucleon, interaction=interaction,
-        m_med=m_med, t=t, **kwargs)
+        m_med=m_med, halo_model=halo_model, t=t, **kwargs)
 
 
 @export
-def rate_wimp_std(es, mw, sigma_nucleon, m_med=float('inf'), t=None, **kwargs):
+def rate_wimp_std(es, mw, sigma_nucleon, m_med=float('inf'),
+        t=None, halo_model = wr.standard_halo_model() , **kwargs):
     """Differential rate per (ton year keV) of WIMP-nucleus scattering.
     :param es: Recoil energies in keV
     :param mw: WIMP mass in GeV/c^2
@@ -62,6 +64,7 @@ def rate_wimp_std(es, mw, sigma_nucleon, m_med=float('inf'), t=None, **kwargs):
     :param m_med: Medator mass in GeV/c^2. If not given, assumed very heavy.
     :param t: A J2000.0 timestamp. If not given,
     conservative velocity distribution is used.
+    :function halo_model : class (similar to the standard halo model) giving velocity distribution and dark matter density
     :returns: numpy array of same length as es
 
     Further arguments are as for rate_wimp; see docstring of rate_wimp.
@@ -69,5 +72,6 @@ def rate_wimp_std(es, mw, sigma_nucleon, m_med=float('inf'), t=None, **kwargs):
     return (rate_wimp(es=es * nu.keV,
                       mw=mw * nu.GeV/nu.c0**2,
                       sigma_nucleon=sigma_nucleon * nu.cm**2,
-                      m_med=m_med * nu.GeV/nu.c0**2, t=t, **kwargs)
+                      m_med=m_med * nu.GeV/nu.c0**2, 
+                      t=t, halo_model=halo_model, **kwargs)
             * (nu.keV * (1000 * nu.kg) * nu.year))


### PR DESCRIPTION
This pull request makes a container class, halo_model that can be used to specify the velocity distribution (standard halo model, with modifiable v_0, escape velocity or user-specified) 

Passing v_0, v_esc, rho_dm as None as default is necessary to pass tests-- if the values are set in the defaults, they will not be updated when numericalunits.reset() is called. 