### PR TITLE
Adding different detection materials for Spin Independent interactions

### DIFF
--- a/wimprates/__init__.py
+++ b/wimprates/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.1'
+__version__ = '0.3.0'
 
 from .utils import *
 from .halo import *

--- a/wimprates/__init__.py
+++ b/wimprates/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 from .utils import *
 from .halo import *

--- a/wimprates/elastic_nr.py
+++ b/wimprates/elastic_nr.py
@@ -13,11 +13,11 @@ export, __all__ = wr.exporter()
 @export
 def an(material='Xe'):
     """Standard atomic weight of target (averaged across all isotopes)"""
-    if material =='Xe':
+    if material is 'Xe':
         return 131.293
-    if material =='Ar':
+    if material is 'Ar':
         return 39.948 
-    if material =='Ge':
+    if material is 'Ge':
         return 72.64
 
 @export
@@ -84,8 +84,6 @@ def helm_form_factor_squared(erec, anucl=None, material='Xe'):
     :param erec: nuclear recoil energy
     :param anucl: Nuclear mass number
     """
-    if material is not 'Xe':
-        raise NotImplementedError("@Joran add formfators")
     if anucl is None:
         anucl = an(material)
     en = erec / nu.keV
@@ -139,7 +137,9 @@ def sigma_erec(erec, v, mw, sigma_nucleon,
                          * an(material)**2)
         result = (sigma_nucleus
                   / e_max(mw, v, mn(material))
-                  * helm_form_factor_squared(erec, anucl=an(material)))
+                  * helm_form_factor_squared(erec,
+                                             anucl=an(material),
+                                             material=material))
 
     elif interaction.startswith('SD'):
         if material is not 'Xe':
@@ -189,7 +189,7 @@ def vmin_elastic(erec, mw, material = 'Xe'):
 @export
 @wr.vectorize_first
 def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
-                 m_med=float('inf'), t=None, material = 'Xe',
+                 m_med=float('inf'), t=None, material='Xe',
                  halo_model=None, **kwargs):
     """Differential rate per unit detector mass and recoil energy of
     elastic WIMP scattering
@@ -212,6 +212,7 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
 
     Analytic expressions are known for this rate, but they are not used here.
     """
+
     halo_model = wr.StandardHaloModel() if halo_model is None else halo_model
     v_min = vmin_elastic(erec, mw, material)
 
@@ -220,7 +221,7 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
 
     def integrand(v):
         return (sigma_erec(erec, v, mw, sigma_nucleon,
-                           interaction, m_med) * v
+                           interaction, m_med, material=material) * v
                 * halo_model.velocity_dist(v, t))
 
     return halo_model.rho_dm / mw * (1 / mn()) * quad(

--- a/wimprates/elastic_nr.py
+++ b/wimprates/elastic_nr.py
@@ -215,6 +215,8 @@ def rate_elastic(erec, mw, sigma_nucleon, interaction='SI',
     If not given, conservative velocity distribution is used.
     :param halo_model: class (default to standard halo model)
     containing velocity distribution
+    :param progress_bar: if True, show a progress bar during evaluation
+    (if erec is an array)
     :param material: name of the detection material (default is 'Xe')
 
     Further kwargs are passed to scipy.integrate.quad numeric integrator

--- a/wimprates/halo.py
+++ b/wimprates/halo.py
@@ -157,7 +157,7 @@ class StandardHaloModel:
         must contain:
         :param v_esc -- escape velocity
         :function velocity_dist -- function taking v,t
-        giving normalised valocity distribution in earth rest-frame.
+        giving normalised velocity distribution in earth rest-frame.
         :param rho_dm -- density in mass/volume of dark matter at the Earth
         The standard halo model also allows variation of v_0
         :param v_0


### PR DESCRIPTION
In this PR I've added an option to also calculate the rate of events in Germanium or Argon-based detectors. I’ve added this option for SI-interactions that should work by default for Xenon-based detectors whereas the other two detection materials could also be specified.

If one would like to also use this option in the functions as introduced in https://github.com/jorana/wimprates/blob/diff_det_targets/wimprates/summary.py, this can be passed on as a kwarg.

PyCharm also did some (minor) PEP 8 changes in the following commit: https://github.com/JelleAalbers/wimprates/commit/3388818148def3f02b08f62357bc5fc7c8529ce9.
