### PR TITLE
Fast J2000 timestamps

### DIFF
--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from wimprates import j2000, StandardHaloModel
+from wimprates import j2000, StandardHaloModel, j200_from_ymd
 import numericalunits as nu
 import numpy as np
 
@@ -9,17 +9,20 @@ def test_shm_values():
     assert np.abs(halo_model.v_0 /(nu.km/nu.s) - 220.)<1e-6
     assert np.abs(halo_model.v_esc /(nu.km/nu.s) - 544.)<1e-6
 
+
 def test_j2000():
-    assert j2000(2009, 1, 31.75) == 3318.25
+    assert j200_from_ymd(2009, 1, 31.75) == 3318.25
 
 
 def test_j2000_datetime():
     date = pd.datetime(year=2009, month=1, day=31, hour=18)
     assert j2000(date=date) == 3318.25
 
+
 def test_j2000_ns_int():
     date = pd.datetime(year=2009, month=1, day=31, hour=18)
     assert j2000(date=pd.to_datetime(date).value) == 3318.25
+
 
 def test_j2000_ns_array():
     date = pd.datetime(year=2009, month=1, day=31, hour=18)

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -16,3 +16,12 @@ def test_j2000():
 def test_j2000_datetime():
     date = pd.datetime(year=2009, month=1, day=31, hour=18)
     assert j2000(date=date) == 3318.25
+
+def test_j2000_ns_int():
+    date = pd.datetime(year=2009, month=1, day=31, hour=18)
+    assert j2000(date=pd.to_datetime(date).value) == 3318.25
+
+def test_j2000_ns_array():
+    date = pd.datetime(year=2009, month=1, day=31, hour=18)
+    dates = np.array([pd.to_datetime(date).value] * 3)
+    np.testing.assert_array_equal(j2000(date=dates), np.array([3318.25] * 3))

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from wimprates import j2000, StandardHaloModel, j200_from_ymd
+from wimprates import j2000, StandardHaloModel, j2000_from_ymd
 import numericalunits as nu
 import numpy as np
 
@@ -11,20 +11,39 @@ def test_shm_values():
 
 
 def test_j2000():
-    assert j200_from_ymd(2009, 1, 31.75) == 3318.25
+    assert j2000_from_ymd(2009, 1, 31.75) == 3318.25
 
 
 def test_j2000_datetime():
     date = pd.datetime(year=2009, month=1, day=31, hour=18)
-    assert j2000(date=date) == 3318.25
+    assert j2000(date) == 3318.25
 
 
 def test_j2000_ns_int():
     date = pd.datetime(year=2009, month=1, day=31, hour=18)
-    assert j2000(date=pd.to_datetime(date).value) == 3318.25
+    value = pd.to_datetime(date).value
+    assert isinstance(value, int)
+    assert j2000(value) == 3318.25
 
 
 def test_j2000_ns_array():
-    date = pd.datetime(year=2009, month=1, day=31, hour=18)
-    dates = np.array([pd.to_datetime(date).value] * 3)
-    np.testing.assert_array_equal(j2000(date=dates), np.array([3318.25] * 3))
+    # Generate some test cases and compare the two implementations
+    years = np.arange(2008, 2020)
+    months = np.arange(1, 12 + 1)
+    days = np.arange(1, 12 + 1)
+    hours = np.arange(1, 12 + 1)
+
+    dates = np.zeros(12)
+    j2000_ymd = np.zeros(12)
+    for i in range(len(j2000_ymd)):
+        print(years[i], months[i], days[i], hours[i])
+        date = pd.datetime(year=years[i],
+                           month=months[i],
+                           day=days[i],
+                           hour=hours[i])
+        dates[i] = pd.to_datetime(date).value
+        # Compute according to j2000_from_ymd
+        j2000_ymd[i] = j2000_from_ymd(years[i],
+                                      months[i],
+                                      days[i] + hours[i] / 24)
+    np.testing.assert_array_almost_equal(j2000(dates), j2000_ymd, decimal=6)

--- a/wimprates/halo.py
+++ b/wimprates/halo.py
@@ -29,7 +29,7 @@ def j2000(date):
     """
     zero = pd.to_datetime('2000-01-01T12:00')
     nanoseconds_per_day = 1e9 * 3600 * 24
-    if isinstance(date, pd.datetime):
+    if isinstance(date, datetime):
         # pd.datetime refers to datetime.datetime
         # make it into a pd.Timestamp
         # Timestamp.value gives timestamp in ns
@@ -40,7 +40,7 @@ def j2000(date):
 
 
 @export
-def j200_from_ymd(year, month, day_of_month):
+def j2000_from_ymd(year, month, day_of_month):
     """"Returns the fractional number of days since J2000.0 epoch.
     :param year: Year
     :param month: Month (January = 1)
@@ -73,7 +73,7 @@ def earth_velocity(t):
     e_2 = np.array([-0.0670, 0.4927, -0.8676])
     # t1 is the time of the vernal equinox, March 21. Does it matter what
     # year? Precession of equinox takes 25800 years so small effect.
-    t1 = j2000(2000, 3, 21)
+    t1 = j2000_from_ymd(2000, 3, 21)
     # Angular frequency
     omega = 2 * np.pi / 365.25
     phi = omega * (t - t1)

--- a/wimprates/halo.py
+++ b/wimprates/halo.py
@@ -26,11 +26,16 @@ def j2000(year=None, month=None, day_of_month=None, date=None):
     Returns the fractional number of days since J2000.0 epoch.
     """
     if date is not None:
-        year = date.year
-        month = date.month
-
-        start_of_month = pd.datetime(year, month, 1)
-        day_of_month = (date - start_of_month) / pd.Timedelta(1, 'D') + 1
+        zero = pd.to_datetime('2000-01-01T12:00')
+        nanoseconds_per_day = 1e9 * 3600 * 24
+        if isinstance(date, pd.datetime):
+            # pd.datetime refers to datetime.datetime
+            # make it into a pd.Timestamp
+            # Timestamp.value gives timestamp in ns
+            date = pd.to_datetime(date).value
+        elif isinstance(date, pd.Timestamp):
+            date = date.value
+        return (date - zero.value) / nanoseconds_per_day
 
     assert month > 0
     assert month < 13

--- a/wimprates/halo.py
+++ b/wimprates/halo.py
@@ -1,5 +1,6 @@
 """Standard halo model: density, and velocity distribution
 """
+from datetime import datetime
 import numericalunits as nu
 import numpy as np
 import pandas as pd
@@ -18,25 +19,34 @@ export, __all__ = wr.exporter()
 #  j2000(2009, 1, 31.75) = 3318.25
 #  j2000(date=pd.to_datetime('2009-1-31 18:00:00') = 3318.25
 @export
-def j2000(year=None, month=None, day_of_month=None, date=None):
-    """Convert calendar date in year, month (starting at 1) and
-    the (possibly fractional) day of the month relative to midnight UT.
-    Either pass year, month and day_of_month or pass pandas datetime object
-    via date argument.
-    Returns the fractional number of days since J2000.0 epoch.
+def j2000(date):
+    """Returns the fractional number of days since J2000.0 epoch.
+    Either pass:
+      * An integer or array of integers (date argument), ns since unix epoch
+      * datetime.datetime object
+      * pd.Timestamp object
+    Day of month starts at 1.
     """
-    if date is not None:
-        zero = pd.to_datetime('2000-01-01T12:00')
-        nanoseconds_per_day = 1e9 * 3600 * 24
-        if isinstance(date, pd.datetime):
-            # pd.datetime refers to datetime.datetime
-            # make it into a pd.Timestamp
-            # Timestamp.value gives timestamp in ns
-            date = pd.to_datetime(date).value
-        elif isinstance(date, pd.Timestamp):
-            date = date.value
-        return (date - zero.value) / nanoseconds_per_day
+    zero = pd.to_datetime('2000-01-01T12:00')
+    nanoseconds_per_day = 1e9 * 3600 * 24
+    if isinstance(date, pd.datetime):
+        # pd.datetime refers to datetime.datetime
+        # make it into a pd.Timestamp
+        # Timestamp.value gives timestamp in ns
+        date = pd.to_datetime(date).value
+    elif isinstance(date, pd.Timestamp):
+        date = date.value
+    return (date - zero.value) / nanoseconds_per_day
 
+
+@export
+def j200_from_ymd(year, month, day_of_month):
+    """"Returns the fractional number of days since J2000.0 epoch.
+    :param year: Year
+    :param month: Month (January = 1)
+    :param day: Day of month (starting from 1), fractional days are
+    relative to midnight UT.
+    """
     assert month > 0
     assert month < 13
 


### PR DESCRIPTION
This speeds up the computation of J2000 timestamps used by wimprates, it is now vectorized and can take a numpy array of `event_time` ns unix timestamps.

Test are added.

The reason for this change is that [Flamedisx](https://github.com/FlamTeam/flamedisx) uses wimprates and calculates a J2000.0 timestamp for each event it simulates. During https://github.com/FlamTeam/flamedisx/pull/58 we realized that flamedisx takes a big performance hit using the current slow implementation of `j2000`