### PR TITLE
Restore python 3.7 compatibility

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,14 +16,16 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: [3.8, 3.9, "3.10" ]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         # Test coveralls (with numba disabled) and normal pytest
         test: [ 'coveralls', 'pytest', ]
         exclude:
+          - python-version: 3.7
+            test: coveralls
           - python-version: 3.9
-            test: pytest
+            test: coveralls
           - python-version: "3.10"
-            test: pytest
+            test: coveralls
     steps:
       - name: Setup python
         uses: actions/setup-python@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,12 +16,11 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
         # Test coveralls (with numba disabled) and normal pytest
         test: [ 'coveralls', 'pytest', ]
+        # Only do coveralls once; pytest on all python versions
+        python-version: [3.8, 3.9, "3.10"]
         exclude:
-          - python-version: 3.7
-            test: coveralls
           - python-version: 3.9
             test: coveralls
           - python-version: "3.10"
@@ -33,7 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repo
         uses: actions/checkout@v3
-      - name: Install requirements for tests and latest strax
+      - name: Install requirements for tests
         run: |
           # Requirements for running the notebooks as a pytest
           pip install cython ipython

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pandas as pd
 from wimprates import j2000, StandardHaloModel, j2000_from_ymd
 import numericalunits as nu
@@ -15,12 +17,12 @@ def test_j2000():
 
 
 def test_j2000_datetime():
-    date = pd.datetime(year=2009, month=1, day=31, hour=18)
+    date = datetime(year=2009, month=1, day=31, hour=18)
     assert j2000(date) == 3318.25
 
 
 def test_j2000_ns_int():
-    date = pd.datetime(year=2009, month=1, day=31, hour=18)
+    date = datetime(year=2009, month=1, day=31, hour=18)
     value = pd.to_datetime(date).value
     assert isinstance(value, int)
     assert j2000(value) == 3318.25
@@ -37,10 +39,10 @@ def test_j2000_ns_array():
     j2000_ymd = np.zeros(12)
     for i in range(len(j2000_ymd)):
         print(years[i], months[i], days[i], hours[i])
-        date = pd.datetime(year=years[i],
-                           month=months[i],
-                           day=days[i],
-                           hour=hours[i])
+        date = datetime(year=years[i],
+                        month=months[i],
+                        day=days[i],
+                       hour=hours[i])
         dates[i] = pd.to_datetime(date).value
         # Compute according to j2000_from_ymd
         j2000_ymd[i] = j2000_from_ymd(years[i],

--- a/wimprates/migdal.py
+++ b/wimprates/migdal.py
@@ -12,7 +12,7 @@ import wimprates as wr
 export, __all__ = wr.exporter()
 
 
-@lru_cache
+@lru_cache()
 def read_migdal_transitions(material='Xe'):
     # Differential transition probabilities for <material> vs energy (eV)
 


### PR DESCRIPTION
Fixes #12 by using the older lru_cache syntax, to restore python 3.7 compatibility. Also cleans up some old pandas syntax in the tests that were causing warnings.