### PR TITLE
Update cicd

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,11 +41,11 @@ jobs:
           pip install setuptools
           # Requirements for running the notebooks as a pytest
           pip install cython ipython
+          pip install jinja2==3.0.3
           pip install nbconvert nbmake pytest-xdist pytest coverage coveralls pytest-cov pytest-notebook ipython_genutils
           # Several optional packages that are imported in the notebooks
           pip install git+https://github.com/XENON1T/laidbax
           pip install -e .
-          pip install -U jinja2
       - name: Test package
         if: matrix.test == 'pytest'
         run:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,19 +29,23 @@ jobs:
             test: coveralls
     steps:
       - name: Setup python
-        uses: actions/setup-python@v5.1.1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repo
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4
       - name: Install requirements for tests
         run: |
+          pip install --upgrade pip
+          # Require setuptools for python3.12 as well
+          pip install setuptools
           # Requirements for running the notebooks as a pytest
           pip install cython ipython
           pip install nbconvert nbmake pytest-xdist pytest coverage coveralls pytest-cov pytest-notebook ipython_genutils
           # Several optional packages that are imported in the notebooks
           pip install git+https://github.com/XENON1T/laidbax
-          python setup.py develop
+          pip install -e .
+          pip install -U jinja2
       - name: Test package
         if: matrix.test == 'pytest'
         run:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,6 +48,7 @@ jobs:
           # Several optional packages that are imported in the notebooks
           pip install git+https://github.com/XENON1T/laidbax
           pip install -e .
+          pip install seaborn matplotlib
       - name: Test package
         if: matrix.test == 'pytest'
         run:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,6 +34,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - name: Install requirements for tests
         run: |
           pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,19 +19,21 @@ jobs:
         # Test coveralls (with numba disabled) and normal pytest
         test: [ 'coveralls', 'pytest', ]
         # Only do coveralls once; pytest on all python versions
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
         exclude:
-          - python-version: 3.8
+          - python-version: 3.10
             test: coveralls
-          - python-version: 3.9
+          - python-version: 3.11
+            test: coveralls
+          - python-version: 3.12
             test: coveralls
     steps:
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.1.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
       - name: Install requirements for tests
         run: |
           # Requirements for running the notebooks as a pytest


### PR DESCRIPTION
With this PR I have updated the CI workflow so that it tests from python3.9 to 3.12 and uses the latest GitHub actions.

The workflow does not invoke setup.py directly anymore as it is now deprecated behaviour.
Also I fixed a bug with nbconvert that requires an older version of the jinja package.